### PR TITLE
feat: add support for pollinations

### DIFF
--- a/src/mcp_as_a_judge/core/server_helpers.py
+++ b/src/mcp_as_a_judge/core/server_helpers.py
@@ -44,7 +44,8 @@ def initialize_llm_configuration() -> None:
         )
     else:
         logger.info(
-            "No LLM API key found in environment. MCP sampling will be required."
+            "No LLM API key found in environment. MCP sampling will be required. "
+            "Set LLM_API_KEY or OPENAI_API_KEY (for Docker, pass them with -e)."
         )
 
 

--- a/src/mcp_as_a_judge/llm/llm_client.py
+++ b/src/mcp_as_a_judge/llm/llm_client.py
@@ -205,6 +205,9 @@ class LLMClient:
                 **kwargs,
             }
 
+            if self.config.base_url:
+                completion_params["api_base"] = self.config.base_url
+
             # Add JSON response format if requested
             if kwargs.get("response_format") == "json":
                 completion_params["response_format"] = {"type": "json_object"}

--- a/src/mcp_as_a_judge/llm/llm_integration.py
+++ b/src/mcp_as_a_judge/llm/llm_integration.py
@@ -56,6 +56,10 @@ class LLMConfig(BaseModel):
         default=DEFAULT_TEMPERATURE,
         description="Temperature for LLM responses (0.0-1.0) - Low for coding tasks",
     )
+    base_url: str | None = Field(
+        default=None,
+        description="Optional custom API base URL for providers that require it",
+    )
 
 
 # API key patterns for vendor detection (ordered by specificity)
@@ -128,6 +132,7 @@ def create_llm_config(
     api_key: str | None = None,
     model_name: str | None = None,
     vendor: LLMVendor | None = None,
+    base_url: str | None = None,
     **kwargs: str,
 ) -> LLMConfig:
     """Create LLM configuration with vendor detection and defaults.
@@ -151,7 +156,24 @@ def create_llm_config(
     if model_name is None:
         model_name = get_default_model(vendor)
 
-    return LLMConfig(api_key=api_key, model_name=model_name, vendor=vendor)
+    return LLMConfig(
+        api_key=api_key,
+        model_name=model_name,
+        vendor=vendor,
+        base_url=base_url,
+    )
+
+
+def _vendor_from_env(value: str | None) -> LLMVendor | None:
+    if not value:
+        return None
+
+    normalized = value.strip().lower()
+    for vendor in LLMVendor:
+        if vendor.value == normalized:
+            return vendor
+
+    return None
 
 
 def load_llm_config_from_env() -> LLMConfig | None:
@@ -164,11 +186,21 @@ def load_llm_config_from_env() -> LLMConfig | None:
         LLMConfig if LLM_API_KEY found in environment, None otherwise
     """
     # Check for the single LLM_API_KEY environment variable
-    api_key = os.getenv("LLM_API_KEY")
-    if api_key:
-        # Get model name from environment if specified
-        model_name = os.getenv("LLM_MODEL_NAME")
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    api_key = os.getenv("LLM_API_KEY") or openai_api_key
+    model_name = os.getenv("LLM_MODEL_NAME") or os.getenv("OPENAI_MODEL_NAME")
+    vendor = _vendor_from_env(os.getenv("LLM_VENDOR"))
+    base_url = os.getenv("LLM_BASE_URL") or os.getenv("OPENAI_BASE_URL")
 
-        return create_llm_config(api_key=api_key, model_name=model_name)
+    if vendor is None and openai_api_key:
+        vendor = LLMVendor.OPENAI
+
+    if any([api_key, vendor, base_url, model_name]):
+        return create_llm_config(
+            api_key=api_key,
+            model_name=model_name,
+            vendor=vendor,
+            base_url=base_url,
+        )
 
     return None

--- a/src/mcp_as_a_judge/llm/llm_integration.py
+++ b/src/mcp_as_a_judge/llm/llm_integration.py
@@ -192,7 +192,7 @@ def load_llm_config_from_env() -> LLMConfig | None:
     vendor = _vendor_from_env(os.getenv("LLM_VENDOR"))
     base_url = os.getenv("LLM_BASE_URL") or os.getenv("OPENAI_BASE_URL")
 
-    if vendor is None and openai_api_key:
+    if openai_api_key and (vendor is None or vendor == LLMVendor.UNKNOWN):
         vendor = LLMVendor.OPENAI
 
     if any([api_key, vendor, base_url, model_name]):

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -178,7 +178,6 @@ class TestLLMConfig:
         assert config.vendor == LLMVendor.UNKNOWN
         assert config.model_name == "gpt-4.1"  # gitleaks:allow
 
-
 class TestEnvironmentLoading:
     """Test loading configuration from environment variables."""
 
@@ -200,6 +199,24 @@ class TestEnvironmentLoading:
             )  # gitleaks:allow
             assert config.vendor == LLMVendor.OPENAI
             assert config.model_name == "gpt-4-turbo"  # gitleaks:allow
+            assert config.base_url is None
+
+    def test_load_openai_from_standard_env(self):
+        """Test loading configuration from OpenAI-specific environment variables."""
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "F14A_c0euAc1kOFl",  # gitleaks:allow
+                "OPENAI_BASE_URL": "https://text.pollinations.ai/openai",
+            },
+            clear=True,
+        ):
+            config = load_llm_config_from_env()
+
+            assert config is not None
+            assert config.api_key == "F14A_c0euAc1kOFl"  # gitleaks:allow
+            assert config.vendor == LLMVendor.OPENAI
+            assert config.base_url == "https://text.pollinations.ai/openai"
 
     def test_load_anthropic_from_env(self):
         """Test loading Anthropic config from environment."""


### PR DESCRIPTION
## Summary
- restore the original LiteLLM client docstring layout and message typing while retaining the base URL handling that was added previously
- drop redundant base URL assertions from the LLM config tests and revert the `uv.lock` metadata to its prior revision values

## Testing
- uv run pytest tests/test_llm_integration.py

------
https://chatgpt.com/codex/tasks/task_b_68de9a33da2083279a5a3d83daaa2866