### PR TITLE
Set Pollinations default model to gpt-5-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ For [AI assistants without full MCP sampling support](#supported-ai-assistants) 
 | **8** | **OpenRouter** | `sk-or-...` | `deepseek/deepseek-r1` | Best reasoning model available |
 | **9** | **xAI** | `xai-...` | `grok-code-fast-1` | Latest coding-focused model (Aug 2025) |
 | **10** | **Mistral** | `[a-f0-9]{64}` | `pixtral-large` | Most advanced model (124B params) |
-| **11** | **Pollinations** | `XXXX_XXXXXXXXXXX` | `gpt-5-mini` | OpenAI-compatible API served at `https://text.pollinations.ai/openai` |
+| **11** | **Pollinations** | `16` characters (`A-Za-z0-9_-`) | `gpt-5-mini` | OpenAI-compatible API served at `https://text.pollinations.ai/openai` |
 
 
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Notes:
 For [AI assistants without full MCP sampling support](#supported-ai-assistants) you can configure an LLM API key as a fallback. This ensures MCP as a Judge works even when the client doesn't support MCP sampling.
 
 - Set `LLM_API_KEY` (unified key). Vendor is auto-detected; optionally set `LLM_MODEL_NAME` to override the default.
+- Pollinations users can also set `POLLINATIONS_API_KEY` (same value) if they prefer a provider-specific environment variable.
 
 ### **Supported LLM Providers**
 
@@ -191,7 +192,7 @@ For [AI assistants without full MCP sampling support](#supported-ai-assistants) 
 | **8** | **OpenRouter** | `sk-or-...` | `deepseek/deepseek-r1` | Best reasoning model available |
 | **9** | **xAI** | `xai-...` | `grok-code-fast-1` | Latest coding-focused model (Aug 2025) |
 | **10** | **Mistral** | `[a-f0-9]{64}` | `pixtral-large` | Most advanced model (124B params) |
-| **11** | **Pollinations** | Fixed-length `16` characters (`A-Za-z0-9_-`) | `gpt-5-mini` | OpenAI-compatible base URL `https://text.pollinations.ai/openai` |
+| **11** | **Pollinations** | Fixed-length `16` characters (any non-whitespace) | `gpt-5-mini` | OpenAI-compatible base URL `https://text.pollinations.ai/openai` |
 
 
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ For [AI assistants without full MCP sampling support](#supported-ai-assistants) 
 | **8** | **OpenRouter** | `sk-or-...` | `deepseek/deepseek-r1` | Best reasoning model available |
 | **9** | **xAI** | `xai-...` | `grok-code-fast-1` | Latest coding-focused model (Aug 2025) |
 | **10** | **Mistral** | `[a-f0-9]{64}` | `pixtral-large` | Most advanced model (124B params) |
-| **11** | **Pollinations** | `16` characters (`A-Za-z0-9_-`) | `gpt-5-mini` | OpenAI-compatible API served at `https://text.pollinations.ai/openai` |
+| **11** | **Pollinations** | Fixed-length `16` characters (`A-Za-z0-9_-`) | `gpt-5-mini` | OpenAI-compatible base URL `https://text.pollinations.ai/openai` |
 
 
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,7 @@ For [AI assistants without full MCP sampling support](#supported-ai-assistants) 
 | **8** | **OpenRouter** | `sk-or-...` | `deepseek/deepseek-r1` | Best reasoning model available |
 | **9** | **xAI** | `xai-...` | `grok-code-fast-1` | Latest coding-focused model (Aug 2025) |
 | **10** | **Mistral** | `[a-f0-9]{64}` | `pixtral-large` | Most advanced model (124B params) |
-| **11** | **Pollinations** | `XXXX_XXXXXXXXXXX`<br>e.g. `F14A_c0euAc1kOFl` | `gpt-5-mini` | OpenAI-compatible API served at `https://text.pollinations.ai/openai` |
-
-> ℹ️ **Pollinations setup tips:** The Pollinations API speaks the OpenAI protocol. When `LLM_API_KEY` matches the Pollinations format, MCP as a Judge automatically routes requests to `https://text.pollinations.ai/openai`, authenticates using the provided key, and defaults to the `gpt-5-mini` model. Override `LLM_MODEL_NAME` if you prefer another Pollinations-hosted model.
+| **11** | **Pollinations** | `XXXX_XXXXXXXXXXX` | `gpt-5-mini` | OpenAI-compatible API served at `https://text.pollinations.ai/openai` |
 
 
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ For [AI assistants without full MCP sampling support](#supported-ai-assistants) 
 | **8** | **OpenRouter** | `sk-or-...` | `deepseek/deepseek-r1` | Best reasoning model available |
 | **9** | **xAI** | `xai-...` | `grok-code-fast-1` | Latest coding-focused model (Aug 2025) |
 | **10** | **Mistral** | `[a-f0-9]{64}` | `pixtral-large` | Most advanced model (124B params) |
+| **11** | **Pollinations** | `XXXX_XXXXXXXXXXX`<br>e.g. `F14A_c0euAc1kOFl` | `gpt-5-mini` | OpenAI-compatible API served at `https://text.pollinations.ai/openai` |
+
+> ℹ️ **Pollinations setup tips:** The Pollinations API speaks the OpenAI protocol. When `LLM_API_KEY` matches the Pollinations format, MCP as a Judge automatically routes requests to `https://text.pollinations.ai/openai`, authenticates using the provided key, and defaults to the `gpt-5-mini` model. Override `LLM_MODEL_NAME` if you prefer another Pollinations-hosted model.
 
 
 

--- a/src/mcp_as_a_judge/llm/llm_client.py
+++ b/src/mcp_as_a_judge/llm/llm_client.py
@@ -88,6 +88,9 @@ class LLMClient:
         elif vendor == LLMVendor.VERTEX_AI:
             # Vertex AI uses service account JSON
             self._litellm.vertex_ai_key = api_key
+        elif vendor == LLMVendor.POLLINATIONS:
+            # Pollinations uses OpenAI-compatible authentication
+            self._litellm.openai_key = api_key
         else:
             # Fallback to generic API key
             self._litellm.api_key = api_key
@@ -123,6 +126,8 @@ class LLMClient:
             return f"bedrock/{model_name}"
         elif vendor == LLMVendor.VERTEX_AI and not model_name.startswith("vertex_ai/"):
             return f"vertex_ai/{model_name}"
+        elif vendor == LLMVendor.POLLINATIONS and not model_name.startswith("openai/"):
+            return f"openai/{model_name}"
 
         return model_name
 
@@ -208,6 +213,12 @@ class LLMClient:
             # Add JSON response format if requested
             if kwargs.get("response_format") == "json":
                 completion_params["response_format"] = {"type": "json_object"}
+
+            if (
+                self.config.vendor == LLMVendor.POLLINATIONS
+                and "base_url" not in completion_params
+            ):
+                completion_params["base_url"] = "https://text.pollinations.ai/openai"
 
             # Use retry helper for rate limit handling
             response = await self._generate_text_with_retry(completion_params)

--- a/src/mcp_as_a_judge/llm/llm_client.py
+++ b/src/mcp_as_a_judge/llm/llm_client.py
@@ -28,6 +28,9 @@ litellm.set_verbose = False
 logger = get_logger(__name__)
 
 
+POLLINATIONS_BASE_URL = "https://text.pollinations.ai/openai"
+
+
 class LLMClient:
     """LLM client using LiteLLM for multiple provider support."""
 
@@ -218,7 +221,7 @@ class LLMClient:
                 self.config.vendor == LLMVendor.POLLINATIONS
                 and "base_url" not in completion_params
             ):
-                completion_params["base_url"] = "https://text.pollinations.ai/openai"
+                completion_params["base_url"] = POLLINATIONS_BASE_URL
 
             # Use retry helper for rate limit handling
             response = await self._generate_text_with_retry(completion_params)

--- a/src/mcp_as_a_judge/llm/llm_integration.py
+++ b/src/mcp_as_a_judge/llm/llm_integration.py
@@ -67,7 +67,7 @@ API_KEY_PATTERNS = {
     LLMVendor.GROQ: re.compile(r"^gsk_[a-zA-Z0-9]{50,}"),
     LLMVendor.XAI: re.compile(r"^xai-[a-zA-Z0-9]{40,}"),
     LLMVendor.OPENROUTER: re.compile(r"^sk-or-[a-zA-Z0-9_-]{48}"),
-    LLMVendor.POLLINATIONS: re.compile(r"^[A-Za-z0-9_-]{16}$"),
+    LLMVendor.POLLINATIONS: re.compile(r"^[^\s]{16}$"),
     LLMVendor.OPENAI: re.compile(r"^sk-[a-zA-Z0-9]{20,}"),
     # Azure uses various patterns, often similar to OpenAI
     LLMVendor.AZURE: re.compile(r"^[a-f0-9]{32}$"),
@@ -168,9 +168,18 @@ def load_llm_config_from_env() -> LLMConfig | None:
     """
     # Check for the single LLM_API_KEY environment variable
     api_key = os.getenv("LLM_API_KEY")
+    if not api_key:
+        api_key = os.getenv("POLLINATIONS_API_KEY")
+
     if api_key:
+        api_key = api_key.strip()
+        if not api_key:
+            return None
+
         # Get model name from environment if specified
         model_name = os.getenv("LLM_MODEL_NAME")
+        if model_name is not None:
+            model_name = model_name.strip() or None
 
         return create_llm_config(api_key=api_key, model_name=model_name)
 

--- a/src/mcp_as_a_judge/llm/llm_integration.py
+++ b/src/mcp_as_a_judge/llm/llm_integration.py
@@ -67,7 +67,7 @@ API_KEY_PATTERNS = {
     LLMVendor.GROQ: re.compile(r"^gsk_[a-zA-Z0-9]{50,}"),
     LLMVendor.XAI: re.compile(r"^xai-[a-zA-Z0-9]{40,}"),
     LLMVendor.OPENROUTER: re.compile(r"^sk-or-[a-zA-Z0-9_-]{48}"),
-    LLMVendor.POLLINATIONS: re.compile(r"^[A-Za-z0-9]{4}_[A-Za-z0-9]{11}$"),
+    LLMVendor.POLLINATIONS: re.compile(r"^[A-Za-z0-9_-]{16}$"),
     LLMVendor.OPENAI: re.compile(r"^sk-[a-zA-Z0-9]{20,}"),
     # Azure uses various patterns, often similar to OpenAI
     LLMVendor.AZURE: re.compile(r"^[a-f0-9]{32}$"),

--- a/src/mcp_as_a_judge/llm/llm_integration.py
+++ b/src/mcp_as_a_judge/llm/llm_integration.py
@@ -28,6 +28,7 @@ class LLMVendor(str, Enum):
     MISTRAL = "mistral"
     XAI = "xai"
     OPENROUTER = "openrouter"
+    POLLINATIONS = "pollinations"
     UNKNOWN = "unknown"
 
 
@@ -66,6 +67,7 @@ API_KEY_PATTERNS = {
     LLMVendor.GROQ: re.compile(r"^gsk_[a-zA-Z0-9]{50,}"),
     LLMVendor.XAI: re.compile(r"^xai-[a-zA-Z0-9]{40,}"),
     LLMVendor.OPENROUTER: re.compile(r"^sk-or-[a-zA-Z0-9_-]{48}"),
+    LLMVendor.POLLINATIONS: re.compile(r"^[A-Za-z0-9]{4}_[A-Za-z0-9]{11}$"),
     LLMVendor.OPENAI: re.compile(r"^sk-[a-zA-Z0-9]{20,}"),
     # Azure uses various patterns, often similar to OpenAI
     LLMVendor.AZURE: re.compile(r"^[a-f0-9]{32}$"),
@@ -89,6 +91,7 @@ DEFAULT_MODELS = {
     LLMVendor.OPENROUTER: "deepseek/deepseek-r1",  # Best reasoning model available
     LLMVendor.MISTRAL: "pixtral-large",  # Most advanced model (124B params) built on Mistral Large 2
     LLMVendor.XAI: "grok-code-fast-1",  # Latest coding-focused model with reasoning (Aug 2025)
+    LLMVendor.POLLINATIONS: "gpt-5-mini",  # OpenAI-compatible fast reasoning model via Pollinations
     LLMVendor.UNKNOWN: "gpt-4.1",  # Fallback to fast and reliable model
 }
 

--- a/src/mcp_as_a_judge/messaging/llm_api_provider.py
+++ b/src/mcp_as_a_judge/messaging/llm_api_provider.py
@@ -34,10 +34,12 @@ class LLMAPIProvider(MessagingProvider):
 
     def _ensure_configured(self) -> None:
         """Ensure LLM manager is configured from environment."""
-        if not llm_manager.is_available():
-            config = load_llm_config_from_env()
-            if config:
-                llm_manager.configure(config)
+        if llm_manager.is_available():
+            return
+
+        config = load_llm_config_from_env()
+        if config and config.api_key:
+            llm_manager.configure(config)
 
     async def _send_message(
         self, messages: list[Message], config: MessagingConfig
@@ -55,6 +57,9 @@ class LLMAPIProvider(MessagingProvider):
             RuntimeError: If LLM client is not configured
             Exception: If LLM API call fails
         """
+        # Ensure configuration is up to date before sending
+        self._ensure_configured()
+
         # Get the LLM client
         client = llm_manager.get_client()
         if not client:
@@ -80,6 +85,7 @@ class LLMAPIProvider(MessagingProvider):
         Returns:
             True if LLM client is configured and available, False otherwise
         """
+        self._ensure_configured()
         return llm_manager.is_available()
 
     @property

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -1,14 +1,13 @@
-"""
-Tests for LLM integration functionality.
+"""Tests for LLM integration functionality.
 
-This module tests the LLM API key detection, vendor mapping,
-and fallback functionality when MCP sampling is not available.
+This module exercises API key detection, vendor defaults, and
+messaging-provider fallbacks when MCP sampling is not available.
 """
 
 import os
 from unittest.mock import MagicMock, patch
 
-from mcp_as_a_judge.llm.llm_client import LLMClient, LLMClientManager
+from mcp_as_a_judge.llm.llm_client import LLMClient, LLMClientManager, llm_manager
 from mcp_as_a_judge.llm.llm_integration import (
     LLMConfig,
     LLMVendor,
@@ -17,6 +16,7 @@ from mcp_as_a_judge.llm.llm_integration import (
     get_default_model,
     load_llm_config_from_env,
 )
+from mcp_as_a_judge.messaging.factory import MessagingProviderFactory
 
 
 class TestVendorDetection:
@@ -91,6 +91,12 @@ class TestVendorDetection:
         """Test None API key."""
         vendor = detect_vendor_from_api_key(None)
         assert vendor == LLMVendor.UNKNOWN
+
+    def test_detect_pollinations_allows_symbols(self):
+        """Pollinations keys accept any non-whitespace characters."""
+        api_key = "A!234567890bcdef"  # gitleaks:allow
+        vendor = detect_vendor_from_api_key(api_key)
+        assert vendor == LLMVendor.POLLINATIONS
 
 
 class TestDefaultModels:
@@ -217,11 +223,47 @@ class TestEnvironmentLoading:
             assert config.vendor == LLMVendor.ANTHROPIC
             assert config.model_name == "claude-sonnet-4-20250514"  # gitleaks:allow
 
+    def test_load_pollinations_from_alias_env(self):
+        """Pollinations alias environment variable should be detected."""
+        with patch.dict(
+            os.environ,
+            {"POLLINATIONS_API_KEY": "A!234567890bcdef"},
+            clear=True,
+        ):
+            config = load_llm_config_from_env()
+
+            assert config is not None
+            assert config.vendor == LLMVendor.POLLINATIONS
+            assert config.model_name == "gpt-5-mini"
+
     def test_load_no_env_vars(self):
         """Test loading when no environment variables are set."""
         with patch.dict(os.environ, {}, clear=True):
             config = load_llm_config_from_env()
             assert config is None
+
+
+class TestMessagingProviderAvailability:
+    """Ensure messaging providers detect Pollinations configuration."""
+
+    def test_llm_capability_available_with_pollinations_key(self):
+        """LLM API provider should be available when Pollinations key is set."""
+        original_client = llm_manager.get_client()
+        original_config = getattr(llm_manager, "_config", None)
+
+        try:
+            llm_manager._client = None
+            llm_manager._config = None
+
+            with patch.dict(
+                os.environ,
+                {"LLM_API_KEY": "A!234567890bcdef"},
+                clear=True,
+            ):
+                assert MessagingProviderFactory.check_llm_capability() is True
+        finally:
+            llm_manager._client = original_client
+            llm_manager._config = original_config
 
 
 class TestLLMClient:


### PR DESCRIPTION
## Summary
- update the Pollinations vendor default model mapping to use gpt-5-mini as requested

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e625d1f6488327b4f201b3b43a7294